### PR TITLE
Attempt at improving dependencies

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -14,8 +14,6 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-openssl:
-- '3'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-openssl:
-- '3'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,8 +6,6 @@ m2w64_c_compiler:
 - m2w64-toolchain
 m2w64_cxx_compiler:
 - m2w64-toolchain
-openssl:
-- '3'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set min_rust = "rust >=1.60" %}
 {% set version = "0.3.13" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set min_rust = "rust >=1.54" %}
 
 package:
@@ -30,10 +30,10 @@ outputs:
         - m2w64-binutils                         # [win]
         - {{ min_rust }}
         - cargo-bundle-licenses
-      host:
         - clangdev                               # [not osx]
         - llvmdev                                # [not osx]
-        - openssl
+      run:
+        - ca-certificates
     test:
       commands:
         - oxigraph_server --version
@@ -55,14 +55,14 @@ outputs:
         - {{ min_rust }}
         - maturin >=0.14.0,<0.15.0
         - cargo-bundle-licenses
-      host:
         - clangdev                               # [not osx]
         - llvmdev                                # [not osx]
-        - openssl
+      host:
         - pip
         - python
       run:
         - python
+        - ca-certificates
     test:
       files:
         - test_licenses.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set min_rust = "rust >=1.54" %}
+{% set min_rust = "rust >=1.60" %}
 {% set version = "0.3.13" %}
 {% set build_number = 0 %}
 {% set min_rust = "rust >=1.54" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
-{% set min_rust = "rust >=1.60" %}
 {% set version = "0.3.13" %}
 {% set build_number = 1 %}
-{% set min_rust = "rust >=1.54" %}
+{% set min_rust = "rust >=1.60" %}
 
 package:
   name: oxigraph


### PR DESCRIPTION
- Clang should be only needed for generating RocksDB bindings at compile time
- Oxigraph now embeds Rustls and only needs the host certificates