### PR TITLE
Updates to v0.3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,5 +181,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@Tpt](https://github.com/Tpt/)
 * [@bollwyvl](https://github.com/bollwyvl/)
 

--- a/recipe/Python__Fixes_the_secondary_test_on_Windows.patch
+++ b/recipe/Python__Fixes_the_secondary_test_on_Windows.patch
@@ -1,0 +1,17 @@
+Subject: [PATCH] Python: Fixes the secondary test on Windows
+---
+Index: python/tests/test_store.py
+<+>UTF-8
+===================================================================
+diff --git a/python/tests/test_store.py b/python/tests/test_store.py
+--- a/python/tests/test_store.py	(revision 4523edebe62c13ca3a53215d9349a4e4f9e62c35)
++++ b/python/tests/test_store.py	(revision ec6477534303ed9f0a95370dde87bc2dbb978a01)
+@@ -367,6 +367,8 @@
+             store.remove(quad)
+             store.flush()
+             self.assertEqual(list(secondary_store), [])
++            del secondary_store
++            del store
+ 
+ 
+ if __name__ == "__main__":

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.3.13" %}
-{% set build_number = 1 %}
 {% set min_rust = "rust >=1.60" %}
+{% set version = "0.3.14" %}
+{% set build_number = 0 %}
 
 package:
   name: oxigraph
@@ -8,7 +8,9 @@ package:
 
 source:
   url: https://github.com/oxigraph/oxigraph/releases/download/v{{ version }}/oxigraph_v{{ version }}.tar.gz
-  sha256: 187cdf0b1685f7ff7d16d69e2c696a20826f7d5da2835f8203a39da6f53d6ec1
+  sha256: d0bcff61bd3aaa046568657652c6871208359e925d1d2c5eb1fd42af2543519b
+  patches:
+    - Python__Fixes_the_secondary_test_on_Windows.patch # TODO: will be integrated into 0.3.15
 
 build:
   number: {{ build_number }}


### PR DESCRIPTION
Backports [a patch to make Python test  work on Windows](https://github.com/oxigraph/oxigraph/commit/9c32f07e87d22480784ad62b987f27243b866a09)